### PR TITLE
Support login config props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,21 @@ This file is used to track notable changes to the codebase
 
 ### Added
 
+- This file
+- Duration support across all functions
+
 ### Changed
 
-### Removed
+- Changed code organization so index.js properly contains only exports 
+- Updated promptForConfig() to accept all options as function parameters. It will also now ask only for items not passed in those parameters.
+- Updated getConfig() to be static. Should have already been.
+- login() now accepts profile, duration, region, and role as parameters. This allows for:
+    - Completely headless calls when the user has multiple roles present in the SAML assertion
+    - Setting a different profile than the default stored in config.
+
+### Fixed
+
+- Now properly sleeps when polling for MFA success
+- Script will properly exit after the default 30 second timeout when polling for MFA sucess
 
 <sup><sub>This files format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)</sub></sup>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# ExtAws
+
+This file is used to track notable changes to the codebase
+
+## [Unreleased]
+
+## [0.0.7] - 2020-09-14
+
+### Added
+
+### Changed
+
+### Removed
+
+<sup><sub>This files format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)</sub></sup>

--- a/README.md
+++ b/README.md
@@ -2,9 +2,13 @@
 
 Typescript package that attempts to solve the problem of getting AWS CLI credentials when using Okta/AWS Saml integration.
 
-It can be used as a CLI command or use the class methods to build additional functionality.
+It was written to be used as both a stand alone CLI for simple use cases or as a utility to build more complex/custom use cases.
 
-Configuration and credentials are stored using the [keytar](https://www.npmjs.com/package/keytar) package which abstracts Windows(Credential Vault)/Mac(Keychain)/Linux(libsecret) secret storage systems
+Configuration and credentials are stored using the [keytar](https://www.npmjs.com/package/keytar) package which abstracts Windows(Credential Vault)/Mac(Keychain)/Linux(libsecret) secret storage systems. 
+
+## Usage
+
+Before you can use this tooling you will need both your Okta organization name(->YourOrgName<-.okta.com) as well as the Okta Saml URL. It'll look something like: `home/amazon_aws/01234abcde9876549/123`
 
 ###CLI
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   ],
   "types": "dist/index.d.ts",
   "bin": {
-    "extaws": "dist/index.js"
+    "extaws": "dist/lib/extaws.js"
   },
   "repository": "git@github.com:helloextend/extaws.git",
   "author": "Corey Ryan <corey@extend.com>",
@@ -25,7 +25,7 @@
     "test": "jest --coverage",
     "test:watch": "jest --coverage --watchAll",
     "clean": "rm -rf coverage dist",
-    "start": "node --no-deprecation -r ts-node/register src/index.ts"
+    "start": "node --no-deprecation -r ts-node/register src/lib/extaws-cli.ts"
   },
   "dependencies": {
     "@types/elementtree": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "extaws",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Extend Okta Aws Authentication",
   "main": "dist/index.js",
   "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
 import { ExtAws } from './lib/extaws'
-import { Config } from './lib/types'
 
-export { ExtAws, Config }
+export { ExtAws }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,4 @@
-#!/usr/bin/env node
-import program from 'commander'
 import { ExtAws } from './lib/extaws'
+import { Config } from './lib/types'
 
-export { ExtAws }
-
-program
-  .version('0.0.1')
-  .name('extaws')
-  .command('init', 'Initialize an AWS with necessary information for this tool', {executableFile: 'lib/init'})
-  .command('login [username] [password]', 'Login to AWS Hub account via Okta', {isDefault: true, executableFile: 'lib/login'})
-  .command('clear', 'Clear locally stores information', {executableFile: 'lib/clear'})
-  .parse(process.argv)
+export { ExtAws, Config }

--- a/src/lib/extaws-cli.ts
+++ b/src/lib/extaws-cli.ts
@@ -1,0 +1,9 @@
+import program from 'commander'
+
+program
+  .version('0.0.1')
+  .name('extaws')
+  .command('init', 'Initialize an AWS with necessary information for this tool', {executableFile: 'init'})
+  .command('login [username] [password]', 'Login to AWS Hub account via Okta', {isDefault: true, executableFile: 'login'})
+  .command('clear', 'Clear locally stores information', {executableFile: 'clear'})
+  .parse(process.argv)

--- a/src/lib/login.ts
+++ b/src/lib/login.ts
@@ -1,11 +1,27 @@
 #!/usr/bin/env node
 import { ExtAws } from './extaws'
+import program from 'commander'
 
-async function login() {
+program
+  .option('-p, --profile <profileName>', 'Name of the AWS Profile to use')
+  .option('-d --duration <durationSeconds>', 'Print a link rather than open a browser session', '43200')
+  .option('-r --region <awsRegion>', 'Region to set as default for the profile')
+  .parse(process.argv)
+
+async function login(profile?: string | undefined, duration?: number | undefined, region?: string | undefined) {
   const extaws = new ExtAws()
-  extaws.login()
+  extaws.login({profile, duration, region})
     .catch(e => console.error(e))
 }
 
-login()
+let duration: number | undefined
+if (program.duration) {
+  duration = parseInt(program.duration)
+  if (isNaN(duration)) {
+    console.error(`Provided duration is invalid: ${program.duration}`)
+    process.exit(1)
+  }
+}
+
+login(program.profile, duration, program.region)
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -27,6 +27,7 @@ export interface Config {
     oktaSamlUrl: string
     saveCreds: boolean
     defaultProfile: string
+    duration: number
     awsRegion: string
 }
 
@@ -65,6 +66,12 @@ export const CONFIG_PROMPT = [
     type: 'input',
     message: 'AWS Profile to store credentials:',
     default: 'default',
+  },
+  {
+    name: 'duration',
+    type: 'number',
+    message: 'Default credential duration (in seconds):',
+    default: 43200,
   },
   {
     name: 'awsRegion',


### PR DESCRIPTION
### Added

- This file
- Duration support across all functions

### Changed

- Changed code organization so index.js properly contains only exports 
- Updated promptForConfig() to accept all options as function parameters. It will also now ask only for items not passed in those parameters.
- Updated getConfig() to be static. Should have already been.
- login() now accepts profile, duration, region, and role as parameters. This allows for:
    - Completely headless calls when the user has multiple roles present in the SAML assertion
    - Setting a different profile than the default stored in config.

### Fixed

- Now properly sleeps when polling for MFA success
- Script will properly exit after the default 30 second timeout when polling for MFA sucess
