### PR TITLE
DEVOPS-992: Added a team filter to login in addition to role

### DIFF
--- a/src/lib/extaws.ts
+++ b/src/lib/extaws.ts
@@ -361,7 +361,7 @@ export class ExtAws {
      * Main method for logging a user into AWS via Okta. Will log a user in and write credentials to aws profile
      * @returns AWS Credentials
      */
-    async login(props?: { profile?: string, duration?: number, region?: string, role?: string }, inputSpinner?: Ora): Promise<STS.Types.AssumeRoleWithSAMLResponse> {
+    async login(props?: { profile?: string, duration?: number, region?: string, role?: string, team?: string, }, inputSpinner?: Ora): Promise<STS.Types.AssumeRoleWithSAMLResponse> {
       const configResult = await ExtAws.getConfig()
       if (configResult === null ) {
         throw new Error('Missing configuration. Please `init`')
@@ -420,7 +420,10 @@ export class ExtAws {
       if (props?.role)  {
         const needle = props.role
         const searchResult = roles.filter(stsRole => {
-          return (~stsRole.role.indexOf(needle))
+          if(props?.team)
+            return (~stsRole.role.indexOf(needle))&&(~stsRole.role.indexOf(props.team))
+          else
+            return (~stsRole.role.indexOf(needle))
         })[0]
         if (searchResult !== undefined) {
           userRole = searchResult

--- a/src/lib/login.ts
+++ b/src/lib/login.ts
@@ -7,11 +7,12 @@ program
   .option('-d --duration <durationSeconds>', 'Print a link rather than open a browser session', '43200')
   .option('-r --region <awsRegion>', 'Region to set as default for the profile')
   .option('-l --role <roleName>', 'Role to pick from SAML assertion. Prompts if not found')
+  .option('-t --team <teamName>', 'Team to pick from SAML assertion. Prompts if not found')
   .parse(process.argv)
 
-async function login(profile?: string | undefined, duration?: number | undefined, region?: string | undefined, role?: string | undefined) {
+async function login(profile?: string | undefined, duration?: number | undefined, region?: string | undefined, role?: string | undefined, team?: string | undefined) {
   const extaws = new ExtAws()
-  extaws.login({profile, duration, region, role})
+  extaws.login({profile, duration, region, role, team})
     .catch(e => console.error(e))
 }
 
@@ -24,5 +25,5 @@ if (program.duration) {
   }
 }
 
-login(program.profile, duration, program.region, program.role)
+login(program.profile, duration, program.region, program.role, program.team)
 


### PR DESCRIPTION
to fix the issue when the user is a member of more than one team with the same role name, example `aws#extend-hub-root#extend_engineering_services_developer#159581800400` and `aws#extend-hub-root#extend_partners_developer#159581800400`. Without team name added as a filter, login always return the first entry from the array, i.e. the login process could be completed with a wrong team.